### PR TITLE
Update activity_id to include CDRMIP and PAMIP

### DIFF
--- a/CMIP6_activity_id.json
+++ b/CMIP6_activity_id.json
@@ -2,6 +2,7 @@
     "activity_id":{
         "AerChemMIP":"Aerosols and Chemistry Model Intercomparison Project",
         "C4MIP":"Coupled Climate Carbon Cycle Model Intercomparison Project",
+        "CDRMIP":"Carbon Dioxide Removal Model Intercomparison Project",
         "CFMIP":"Cloud Feedback Model Intercomparison Project",
         "CMIP":"CMIP DECK: 1pctCO2, abrupt4xCO2, amip, esm-piControl, esm-historical, historical, and piControl experiments",
         "CORDEX":"Coordinated Regional Climate Downscaling Experiment",
@@ -16,6 +17,7 @@
         "LS3MIP":"Land Surface, Snow and Soil Moisture",
         "LUMIP":"Land-Use Model Intercomparison Project",
         "OMIP":"Ocean Model Intercomparison Project",
+        "PAMIP":"Polar Amplification Model Intercomparison Project",
         "PMIP":"Palaeoclimate Modelling Intercomparison Project",
         "RFMIP":"Radiative Forcing Model Intercomparison Project",
         "SIMIP":"Sea Ice Model Intercomparison Project",
@@ -24,12 +26,12 @@
         "VolMIP":"Volcanic Forcings Model Intercomparison Project"
     },
     "version_metadata":{
-        "CV_collection_modified":"Mon Mar  5 16:09:56 2018 -0800",
-        "CV_collection_version":"6.2.2.4",
+        "CV_collection_modified":"Mon Mar  5 16:39:09 2018 -0800",
+        "CV_collection_version":"6.2.3.0",
         "activity_id_CV_modified":"Thu Sep 7 10:30:00 2017 -0700",
-        "activity_id_CV_note":"Issue397 durack1 augment activity_id with description (#400)",
+        "activity_id_CV_note":"Update activity_id to include CDRMIP and PAMIP",
         "author":"Paul J. Durack <durack1@llnl.gov>",
         "institution_id":"PCMDI",
-        "previous_commit":"c6504f44d38b0ac37eef862a75e6bccc4da20c95"
+        "previous_commit":"1978084b171c7822174b979b042a05326a25ad1d"
     }
 }

--- a/CMIP6_experiment_id.json
+++ b/CMIP6_experiment_id.json
@@ -7278,12 +7278,12 @@
         }
     },
     "version_metadata":{
-        "CV_collection_modified":"Mon Mar  5 16:09:56 2018 -0800",
-        "CV_collection_version":"6.2.2.4",
+        "CV_collection_modified":"Mon Mar  5 16:39:09 2018 -0800",
+        "CV_collection_version":"6.2.3.0",
         "author":"Paul J. Durack <durack1@llnl.gov>",
         "experiment_id_CV_modified":"Fri Feb 23 20:21:26 2018 -0800",
         "experiment_id_CV_note":"\"Validate source_id entries against CVs\"",
         "institution_id":"PCMDI",
-        "previous_commit":"c6504f44d38b0ac37eef862a75e6bccc4da20c95"
+        "previous_commit":"1978084b171c7822174b979b042a05326a25ad1d"
     }
 }

--- a/CMIP6_frequency.json
+++ b/CMIP6_frequency.json
@@ -18,12 +18,12 @@
         "yrPt":"sampled yearly, at specified time point within the time period"
     },
     "version_metadata":{
-        "CV_collection_modified":"Mon Mar  5 16:09:56 2018 -0800",
-        "CV_collection_version":"6.2.2.4",
+        "CV_collection_modified":"Mon Mar  5 16:39:09 2018 -0800",
+        "CV_collection_version":"6.2.3.0",
         "author":"Paul J. Durack <durack1@llnl.gov>",
         "frequency_CV_modified":"Fri Oct 27 14:03:00 2017 -0700",
         "frequency_CV_note":"Issue414 durack1 revise frequency 1hrCM definition (#418)",
         "institution_id":"PCMDI",
-        "previous_commit":"c6504f44d38b0ac37eef862a75e6bccc4da20c95"
+        "previous_commit":"1978084b171c7822174b979b042a05326a25ad1d"
     }
 }

--- a/CMIP6_grid_label.json
+++ b/CMIP6_grid_label.json
@@ -47,12 +47,12 @@
         "grz":"regridded zonal mean data reported on the data provider's preferred latitude target grid"
     },
     "version_metadata":{
-        "CV_collection_modified":"Mon Mar  5 16:09:56 2018 -0800",
-        "CV_collection_version":"6.2.2.4",
+        "CV_collection_modified":"Mon Mar  5 16:39:09 2018 -0800",
+        "CV_collection_version":"6.2.3.0",
         "author":"Paul J. Durack <durack1@llnl.gov>",
         "grid_label_CV_modified":"Fri Sep 8 18:12:00 2017 -0700",
         "grid_label_CV_note":"Issue395 durack1 augment grid_label with description (#401)",
         "institution_id":"PCMDI",
-        "previous_commit":"c6504f44d38b0ac37eef862a75e6bccc4da20c95"
+        "previous_commit":"1978084b171c7822174b979b042a05326a25ad1d"
     }
 }

--- a/CMIP6_institution_id.json
+++ b/CMIP6_institution_id.json
@@ -39,12 +39,12 @@
         "UHH":"Universitat Hamburg, Hamburg 20148, Germany"
     },
     "version_metadata":{
-        "CV_collection_modified":"Mon Mar  5 16:09:56 2018 -0800",
-        "CV_collection_version":"6.2.2.4",
+        "CV_collection_modified":"Mon Mar  5 16:39:09 2018 -0800",
+        "CV_collection_version":"6.2.3.0",
         "author":"Paul J. Durack <durack1@llnl.gov>",
         "institution_id":"PCMDI",
         "institution_id_CV_modified":"Tue Feb 27 08:55:55 2018 -0800",
         "institution_id_CV_note":"Register institution_id KIOST",
-        "previous_commit":"c6504f44d38b0ac37eef862a75e6bccc4da20c95"
+        "previous_commit":"1978084b171c7822174b979b042a05326a25ad1d"
     }
 }

--- a/CMIP6_license.json
+++ b/CMIP6_license.json
@@ -3,12 +3,12 @@
         "CMIP6 model data produced by <Your Centre Name> is licensed under a Creative Commons Attribution-[NonCommercial-]ShareAlike 4.0 International License (https://creativecommons.org/licenses). Consult https://pcmdi.llnl.gov/CMIP6/TermsOfUse for terms of use governing CMIP6 output, including citation requirements and proper acknowledgment. Further information about this data, including some limitations, can be found via the further_info_url (recorded as a global attribute in this file)[ and at <some URL maintained by modeling group>]. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law."
     ],
     "version_metadata":{
-        "CV_collection_modified":"Mon Mar  5 16:09:56 2018 -0800",
-        "CV_collection_version":"6.2.2.4",
+        "CV_collection_modified":"Mon Mar  5 16:39:09 2018 -0800",
+        "CV_collection_version":"6.2.3.0",
         "author":"Paul J. Durack <durack1@llnl.gov>",
         "institution_id":"PCMDI",
         "license_CV_modified":"Mon Feb 27 10:30:00 2017 -0700",
         "license_CV_note":"Issue225 durack1 add institution_id THU (#232)",
-        "previous_commit":"c6504f44d38b0ac37eef862a75e6bccc4da20c95"
+        "previous_commit":"1978084b171c7822174b979b042a05326a25ad1d"
     }
 }

--- a/CMIP6_nominal_resolution.json
+++ b/CMIP6_nominal_resolution.json
@@ -17,12 +17,12 @@
         "5000 km"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Mon Mar  5 16:09:56 2018 -0800",
-        "CV_collection_version":"6.2.2.4",
+        "CV_collection_modified":"Mon Mar  5 16:39:09 2018 -0800",
+        "CV_collection_version":"6.2.3.0",
         "author":"Paul J. Durack <durack1@llnl.gov>",
         "institution_id":"PCMDI",
         "nominal_resolution_CV_modified":"Tues Nov 15 16:04:00 2016 -0700",
         "nominal_resolution_CV_note":"Issue141 durack1 update grid_resolution to nominal_resolution (#143)",
-        "previous_commit":"c6504f44d38b0ac37eef862a75e6bccc4da20c95"
+        "previous_commit":"1978084b171c7822174b979b042a05326a25ad1d"
     }
 }

--- a/CMIP6_realm.json
+++ b/CMIP6_realm.json
@@ -10,11 +10,11 @@
         "seaIce":"Sea Ice"
     },
     "version_metadata":{
-        "CV_collection_modified":"Mon Mar  5 16:09:56 2018 -0800",
-        "CV_collection_version":"6.2.2.4",
+        "CV_collection_modified":"Mon Mar  5 16:39:09 2018 -0800",
+        "CV_collection_version":"6.2.3.0",
         "author":"Paul J. Durack <durack1@llnl.gov>",
         "institution_id":"PCMDI",
-        "previous_commit":"c6504f44d38b0ac37eef862a75e6bccc4da20c95",
+        "previous_commit":"1978084b171c7822174b979b042a05326a25ad1d",
         "realm_CV_modified":"Tues Apr 18 12:03:00 2017 -0700",
         "realm_CV_note":"Issue285 durack1 update realm format (#290)"
     }

--- a/CMIP6_required_global_attributes.json
+++ b/CMIP6_required_global_attributes.json
@@ -32,11 +32,11 @@
         "variant_label"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Mon Mar  5 16:09:56 2018 -0800",
-        "CV_collection_version":"6.2.2.4",
+        "CV_collection_modified":"Mon Mar  5 16:39:09 2018 -0800",
+        "CV_collection_version":"6.2.3.0",
         "author":"Paul J. Durack <durack1@llnl.gov>",
         "institution_id":"PCMDI",
-        "previous_commit":"c6504f44d38b0ac37eef862a75e6bccc4da20c95",
+        "previous_commit":"1978084b171c7822174b979b042a05326a25ad1d",
         "required_global_attributes_CV_modified":"Thu Mar 16 12:59:00 2017 -0700",
         "required_global_attributes_CV_note":"deleted trailing comma from list"
     }

--- a/CMIP6_source_id.json
+++ b/CMIP6_source_id.json
@@ -4013,12 +4013,12 @@
         }
     },
     "version_metadata":{
-        "CV_collection_modified":"Mon Mar  5 16:09:56 2018 -0800",
-        "CV_collection_version":"6.2.2.4",
+        "CV_collection_modified":"Mon Mar  5 16:39:09 2018 -0800",
+        "CV_collection_version":"6.2.3.0",
         "author":"Paul J. Durack <durack1@llnl.gov>",
         "institution_id":"PCMDI",
-        "previous_commit":"c6504f44d38b0ac37eef862a75e6bccc4da20c95",
-        "source_id_CV_modified":"Mon Mar  5 15:26:48 2018 -0800",
+        "previous_commit":"1978084b171c7822174b979b042a05326a25ad1d",
+        "source_id_CV_modified":"Mon Mar  5 16:09:56 2018 -0800",
         "source_id_CV_note":"Update activity_participation entries to include CMIP"
     }
 }

--- a/CMIP6_source_type.json
+++ b/CMIP6_source_type.json
@@ -12,11 +12,11 @@
         "SLAB":"slab-ocean used with an AGCM in representing the atmosphere-ocean coupled system"
     },
     "version_metadata":{
-        "CV_collection_modified":"Mon Mar  5 16:09:56 2018 -0800",
-        "CV_collection_version":"6.2.2.4",
+        "CV_collection_modified":"Mon Mar  5 16:39:09 2018 -0800",
+        "CV_collection_version":"6.2.3.0",
         "author":"Paul J. Durack <durack1@llnl.gov>",
         "institution_id":"PCMDI",
-        "previous_commit":"c6504f44d38b0ac37eef862a75e6bccc4da20c95",
+        "previous_commit":"1978084b171c7822174b979b042a05326a25ad1d",
         "source_type_CV_modified":"Fri Sep 8 17:57:00 2017 -0700",
         "source_type_CV_note":"Issue396 durack1 augment source_type with description (#399)"
     }

--- a/CMIP6_sub_experiment_id.json
+++ b/CMIP6_sub_experiment_id.json
@@ -75,11 +75,11 @@
         "s2029":"initialized near end of year 2029"
     },
     "version_metadata":{
-        "CV_collection_modified":"Mon Mar  5 16:09:56 2018 -0800",
-        "CV_collection_version":"6.2.2.4",
+        "CV_collection_modified":"Mon Mar  5 16:39:09 2018 -0800",
+        "CV_collection_version":"6.2.3.0",
         "author":"Paul J. Durack <durack1@llnl.gov>",
         "institution_id":"PCMDI",
-        "previous_commit":"c6504f44d38b0ac37eef862a75e6bccc4da20c95",
+        "previous_commit":"1978084b171c7822174b979b042a05326a25ad1d",
         "sub_experiment_id_CV_modified":"Wed Mar 8 11:27:00 2017 -0700",
         "sub_experiment_id_CV_note":"Issue1 durack1 update experiment_id from spreadsheet (MIP-chair review) (#241)"
     }

--- a/CMIP6_table_id.json
+++ b/CMIP6_table_id.json
@@ -45,11 +45,11 @@
         "fx"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Mon Mar  5 16:09:56 2018 -0800",
-        "CV_collection_version":"6.2.2.4",
+        "CV_collection_modified":"Mon Mar  5 16:39:09 2018 -0800",
+        "CV_collection_version":"6.2.3.0",
         "author":"Paul J. Durack <durack1@llnl.gov>",
         "institution_id":"PCMDI",
-        "previous_commit":"c6504f44d38b0ac37eef862a75e6bccc4da20c95",
+        "previous_commit":"1978084b171c7822174b979b042a05326a25ad1d",
         "table_id_CV_modified":"Fri Jan 13 09:27:00 2017 -0700",
         "table_id_CV_note":"Issue199 durack1 update table_id to Data Request v1.0 (#200)"
     }

--- a/mip_era.json
+++ b/mip_era.json
@@ -7,12 +7,12 @@
         "CMIP6"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Mon Mar  5 16:09:56 2018 -0800",
-        "CV_collection_version":"6.2.2.4",
+        "CV_collection_modified":"Mon Mar  5 16:39:09 2018 -0800",
+        "CV_collection_version":"6.2.3.0",
         "author":"Paul J. Durack <durack1@llnl.gov>",
         "institution_id":"PCMDI",
         "mip_era_CV_modified":"Thu Aug 25 17:21:00 2016 -0700",
         "mip_era_CV_note":"Fix #36 - Add CV name to json structure",
-        "previous_commit":"c6504f44d38b0ac37eef862a75e6bccc4da20c95"
+        "previous_commit":"1978084b171c7822174b979b042a05326a25ad1d"
     }
 }

--- a/src/versionHistory.json
+++ b/src/versionHistory.json
@@ -1,10 +1,10 @@
 {
     "versionHistory":{
         "activity_id":{
-            "MD5":"c28217095e8ca770b6cd63fa97b8d022ca52aea7",
-            "URL":"https://github.com/WCRP-CMIP/CMIP6_CVs/commit/c28217095e8ca770b6cd63fa97b8d022ca52aea7",
-            "commitMessage":"Issue397 durack1 augment activity_id with description (#400)",
-            "timeStamp":"Thu Sep 7 10:30:00 2017 -0700"
+            "MD5":"1978084b171c7822174b979b042a05326a25ad1d",
+            "URL":"https://github.com/WCRP-CMIP/CMIP6_CVs/commit/1978084b171c7822174b979b042a05326a25ad1d",
+            "commitMessage":"Update activity_id to include CDRMIP and PAMIP",
+            "timeStamp":"Mon Mar  5 16:39:09 2018 -0800"
         },
         "experiment_id":{
             "MD5":"dd84a7f76a3591edb9ddb37f7dcf058466940657",
@@ -85,8 +85,8 @@
             "timeStamp":"Fri Jan 13 09:27:00 2017 -0700"
         },
         "versions":{
-            "versionCVCommit":4,
-            "versionCVContent":2,
+            "versionCVCommit":0,
+            "versionCVContent":3,
             "versionCVStructure":2,
             "versionMIPEra":6
         }

--- a/src/writeJson.py
+++ b/src/writeJson.py
@@ -247,14 +247,15 @@ PJD  5 Mar 2018    - Updated versionHistory to be obtained from the repo https:/
 PJD  5 Mar 2018    - Register source_id KIOST-ESM https://github.com/WCRP-CMIP/CMIP6_CVs/issues/469
 PJD  5 Mar 2018    - Update activity_participation for source_id CNRM-CM6-1 https://github.com/WCRP-CMIP/CMIP6_CVs/issues/471
 PJD  5 Mar 2018    - Update activity_participation entries to include CMIP https://github.com/WCRP-CMIP/CMIP6_CVs/issues/468
-                   - TODO: Check all source_id activity_participation entries against activity_id list
+PJD  5 Mar 2018    - Update activity_id to include CDRMIP and PAMIP https://github.com/WCRP-CMIP/CMIP6_CVs/issues/455
+PJD  5 Mar 2018    - Updated versionHistory to be obtained from the repo https://github.com/WCRP-CMIP/CMIP6_CVs/issues/468
                    - TODO: Generate table_id from dataRequest https://github.com/WCRP-CMIP/CMIP6_CVs/issues/166
 
 @author: durack1
 """
 
 #%% Set commit message
-commitMessage = '\"Update activity_participation entries to include CMIP\"'
+commitMessage = '\"Update activity_id to include CDRMIP and PAMIP\"'
 
 #%% Import statements
 import calendar
@@ -291,6 +292,7 @@ masterTargets = [
 activity_id = {
     'AerChemMIP': 'Aerosols and Chemistry Model Intercomparison Project',
     'C4MIP': 'Coupled Climate Carbon Cycle Model Intercomparison Project',
+    'CDRMIP': 'Carbon Dioxide Removal Model Intercomparison Project',
     'CFMIP': 'Cloud Feedback Model Intercomparison Project',
     'CMIP': 'CMIP DECK: 1pctCO2, abrupt4xCO2, amip, esm-piControl, esm-historical, historical, and piControl experiments',
     'CORDEX': 'Coordinated Regional Climate Downscaling Experiment',
@@ -305,6 +307,7 @@ activity_id = {
     'LS3MIP': 'Land Surface, Snow and Soil Moisture',
     'LUMIP': 'Land-Use Model Intercomparison Project',
     'OMIP': 'Ocean Model Intercomparison Project',
+    'PAMIP': 'Polar Amplification Model Intercomparison Project',
     'PMIP': 'Palaeoclimate Modelling Intercomparison Project',
     'RFMIP': 'Radiative Forcing Model Intercomparison Project',
     'SIMIP': 'Sea Ice Model Intercomparison Project',
@@ -536,42 +539,6 @@ source_id = source_id.get('source_id') ; # Fudge to extract duplicate level
 del(tmp)
 
 # Fix issues
-key = 'AWI-CM-1-0-HR'
-acts = source_id[key]['activity_participation']
-acts.append('CMIP') ; acts.sort()
-source_id[key]['activity_participation'] = acts
-key = 'EC-Earth3-HR'
-acts = source_id[key]['activity_participation']
-acts.append('CMIP') ; acts.sort()
-source_id[key]['activity_participation'] = acts
-key = 'IPSL-CM6A-LR'
-acts = source_id[key]['activity_participation']
-acts.append('CMIP') ; acts.sort()
-source_id[key]['activity_participation'] = acts
-key = 'NICAM16-7S'
-acts = source_id[key]['activity_participation']
-acts.append('CMIP') ; acts.sort()
-source_id[key]['activity_participation'] = acts
-key = 'NICAM16-8S'
-acts = source_id[key]['activity_participation']
-acts.append('CMIP') ; acts.sort()
-source_id[key]['activity_participation'] = acts
-key = 'NICAM16-9D-L78'
-acts = source_id[key]['activity_participation']
-acts.append('CMIP') ; acts.sort()
-source_id[key]['activity_participation'] = acts
-key = 'NICAM16-9S'
-acts = source_id[key]['activity_participation']
-acts.append('CMIP') ; acts.sort()
-source_id[key]['activity_participation'] = acts
-key = 'NorESM2-HH'
-acts = source_id[key]['activity_participation']
-acts.append('CMIP') ; acts.sort()
-source_id[key]['activity_participation'] = acts
-key = 'NorESM2-LMEC'
-acts = source_id[key]['activity_participation']
-acts.append('CMIP') ; acts.sort()
-source_id[key]['activity_participation'] = acts
 #==============================================================================
 #key = 'AWI-CM-1-0-HR'
 #source_id[key] = {}
@@ -989,6 +956,13 @@ del(testVal_activity_id,testVal_experiment_id,testVal_frequency,testVal_grid_lab
 args = shlex.split(''.join(['git commit -am ',commitMessage]))
 p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd='./')
 
+# Load master history direct from repo
+tmp = [['versionHistory','https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/src/versionHistory.json']
+  ] ;
+versionHistory = readJsonCreateDict(tmp)
+versionHistory = versionHistory.get('versionHistory')
+versionHistory = versionHistory.get('versionHistory') ; # Fudge to extract duplicate level
+del(tmp)
 # Test for version change and push tag
 versions = versionHistory['versions']
 versionOld = '.'.join([str(versions['versionMIPEra']),str(versions['versionCVStructure']),


### PR DESCRIPTION
Ref #455 

`experiment_id` entries are still required to be updated to reflect the new `activity_id` entries