### PR TITLE
Update CMIP6_source_id.json

### DIFF
--- a/CMIP6_source_id.json
+++ b/CMIP6_source_id.json
@@ -2195,6 +2195,7 @@
             "activity_participation":[
                 "CFMIP",
                 "CMIP",
+                "PAMIP",
                 "ScenarioMIP"
             ],
             "cohort":[


### PR DESCRIPTION
Adds PAMIP to the E3SM-1-0 activity participation
