### PR TITLE
Add a check to ensure the maximum source id limit of 25 characters is respected

### DIFF
--- a/src/writeJson.py
+++ b/src/writeJson.py
@@ -1148,6 +1148,20 @@ source_id[key]['institution_id'] = [
 #source_id.pop(key1)
 
 '''
+Apply a check on the length of source ids. Raise a RuntimeError if any are found.
+'''
+MAX_SOURCE_ID_LENGTH = 25
+MAX_SOURCE_ID_MSG_TEMPLATE = 'Source id "{}" is {} characters long which is above the limit of {}'
+# Check all source ids for length
+long_source_ids = [i for i in source_id if len(i) > MAX_SOURCE_ID_LENGTH]
+errors = [MAX_SOURCE_ID_MSG_TEMPLATE.format(i, len(i), MAX_SOURCE_ID_LENGTH) for i in long_source_ids]
+# Raise exception if any found
+if errors:
+    raise RuntimeError('. '.join(errors))
+
+del(long_source_ids, errors)
+
+'''
 Descriptors were documented in http://pcmdi.github.io/projects/cmip5/CMIP5_output_metadata_requirements.pdf?id=76
 Information above can be found in AR5 Table 9.A.1 http://www.climatechange2013.org/images/report/WG1AR5_Chapter09_FINAL.pdf#page=114
 '''


### PR DESCRIPTION
If issue found raise a RuntimeError (i.e. stop with a useful message).

Addresses #1054 

This is a fairly simple change to enforce the character limit on source_ids. There are a number of ways we could do this, but this seems functional. I've adhoc tested it (insert `source_id['x' * 30] = {}` above this check) and it behaves as expected.

@durack1, this is my attempt to cover the action at the last WIP meeting -- let me know if you have any thoughts.