### PR TITLE
Add source_id UKESM1-1-LL

### DIFF
--- a/CMIP6_activity_id.json
+++ b/CMIP6_activity_id.json
@@ -26,13 +26,13 @@
         "VolMIP":"Volcanic Forcings Model Intercomparison Project"
     },
     "version_metadata":{
-        "CV_collection_modified":"Fri Feb 18 16:16:09 2022 -0800",
-        "CV_collection_version":"6.2.56.10",
+        "CV_collection_modified":"Wed Apr 13 13:21:31 2022 00100",
+        "CV_collection_version":"6.2.56.11",
         "activity_id_CV_modified":"Mon Mar  5 16:39:09 2018 -0800",
         "activity_id_CV_note":"Update activity_id to include CDRMIP and PAMIP",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"ba0173c3a83bb3df5034bf2c5739cc0eb3237622",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"451e55b674be3fbab62dd8241840bbae237943bd",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_experiment_id.json
+++ b/CMIP6_experiment_id.json
@@ -9456,13 +9456,13 @@
         }
     },
     "version_metadata":{
-        "CV_collection_modified":"Fri Feb 18 16:16:09 2022 -0800",
-        "CV_collection_version":"6.2.56.10",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
+        "CV_collection_modified":"Wed Apr 13 13:21:31 2022 00100",
+        "CV_collection_version":"6.2.56.11",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "experiment_id_CV_modified":"Tue Dec 15 12:25:59 2020 -0800",
         "experiment_id_CV_note":"Revise experiment_id historical parent experiments",
-        "institution_id":"PCMDI",
-        "previous_commit":"ba0173c3a83bb3df5034bf2c5739cc0eb3237622",
+        "institution_id":"MOHC",
+        "previous_commit":"451e55b674be3fbab62dd8241840bbae237943bd",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_frequency.json
+++ b/CMIP6_frequency.json
@@ -18,13 +18,13 @@
         "yrPt":"sampled yearly, at specified time point within the time period"
     },
     "version_metadata":{
-        "CV_collection_modified":"Fri Feb 18 16:16:09 2022 -0800",
-        "CV_collection_version":"6.2.56.10",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
+        "CV_collection_modified":"Wed Apr 13 13:21:31 2022 00100",
+        "CV_collection_version":"6.2.56.11",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "frequency_CV_modified":"Mon May 24 13:48:15 2021 00100",
         "frequency_CV_note":"Update description of 3hr and 6hr frequencies",
-        "institution_id":"PCMDI",
-        "previous_commit":"ba0173c3a83bb3df5034bf2c5739cc0eb3237622",
+        "institution_id":"MOHC",
+        "previous_commit":"451e55b674be3fbab62dd8241840bbae237943bd",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_grid_label.json
+++ b/CMIP6_grid_label.json
@@ -47,13 +47,13 @@
         "grz":"regridded zonal mean data reported on the data provider's preferred latitude target grid"
     },
     "version_metadata":{
-        "CV_collection_modified":"Fri Feb 18 16:16:09 2022 -0800",
-        "CV_collection_version":"6.2.56.10",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
+        "CV_collection_modified":"Wed Apr 13 13:21:31 2022 00100",
+        "CV_collection_version":"6.2.56.11",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "grid_label_CV_modified":"Fri Sep 8 18:12:00 2017 -0700",
         "grid_label_CV_note":"Issue395 durack1 augment grid_label with description (#401)",
-        "institution_id":"PCMDI",
-        "previous_commit":"ba0173c3a83bb3df5034bf2c5739cc0eb3237622",
+        "institution_id":"MOHC",
+        "previous_commit":"451e55b674be3fbab62dd8241840bbae237943bd",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_institution_id.json
+++ b/CMIP6_institution_id.json
@@ -55,13 +55,13 @@
         "UofT":"Department of Physics, University of Toronto, 60 St George Street, Toronto, ON M5S1A7, Canada"
     },
     "version_metadata":{
-        "CV_collection_modified":"Fri Feb 18 16:16:09 2022 -0800",
-        "CV_collection_version":"6.2.56.10",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
+        "CV_collection_modified":"Wed Apr 13 13:21:31 2022 00100",
+        "CV_collection_version":"6.2.56.11",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
         "institution_id_CV_modified":"Mon Nov 16 11:16:39 2020 -0800",
         "institution_id_CV_note":"Register institution_id LLNL; Py3 cleanup",
-        "previous_commit":"ba0173c3a83bb3df5034bf2c5739cc0eb3237622",
+        "previous_commit":"451e55b674be3fbab62dd8241840bbae237943bd",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_license.json
+++ b/CMIP6_license.json
@@ -3,13 +3,13 @@
         "CMIP6 model data produced by <Your Centre Name> is licensed under a Creative Commons Attribution-[NonCommercial-]ShareAlike 4.0 International License (https://creativecommons.org/licenses). Consult https://pcmdi.llnl.gov/CMIP6/TermsOfUse for terms of use governing CMIP6 output, including citation requirements and proper acknowledgment. Further information about this data, including some limitations, can be found via the further_info_url (recorded as a global attribute in this file)[ and at <some URL maintained by modeling group>]. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law."
     ],
     "version_metadata":{
-        "CV_collection_modified":"Fri Feb 18 16:16:09 2022 -0800",
-        "CV_collection_version":"6.2.56.10",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
+        "CV_collection_modified":"Wed Apr 13 13:21:31 2022 00100",
+        "CV_collection_version":"6.2.56.11",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
         "license_CV_modified":"Mon Feb 27 10:30:00 2017 -0700",
         "license_CV_note":"Issue225 durack1 add institution_id THU (#232)",
-        "previous_commit":"ba0173c3a83bb3df5034bf2c5739cc0eb3237622",
+        "previous_commit":"451e55b674be3fbab62dd8241840bbae237943bd",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_nominal_resolution.json
+++ b/CMIP6_nominal_resolution.json
@@ -17,13 +17,13 @@
         "5000 km"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Fri Feb 18 16:16:09 2022 -0800",
-        "CV_collection_version":"6.2.56.10",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
+        "CV_collection_modified":"Wed Apr 13 13:21:31 2022 00100",
+        "CV_collection_version":"6.2.56.11",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
         "nominal_resolution_CV_modified":"Tues Nov 15 16:04:00 2016 -0700",
         "nominal_resolution_CV_note":"Issue141 durack1 update grid_resolution to nominal_resolution (#143)",
-        "previous_commit":"ba0173c3a83bb3df5034bf2c5739cc0eb3237622",
+        "previous_commit":"451e55b674be3fbab62dd8241840bbae237943bd",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_realm.json
+++ b/CMIP6_realm.json
@@ -10,11 +10,11 @@
         "seaIce":"Sea Ice"
     },
     "version_metadata":{
-        "CV_collection_modified":"Fri Feb 18 16:16:09 2022 -0800",
-        "CV_collection_version":"6.2.56.10",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"ba0173c3a83bb3df5034bf2c5739cc0eb3237622",
+        "CV_collection_modified":"Wed Apr 13 13:21:31 2022 00100",
+        "CV_collection_version":"6.2.56.11",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"451e55b674be3fbab62dd8241840bbae237943bd",
         "realm_CV_modified":"Tues Apr 18 12:03:00 2017 -0700",
         "realm_CV_note":"Issue285 durack1 update realm format (#290)",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"

--- a/CMIP6_required_global_attributes.json
+++ b/CMIP6_required_global_attributes.json
@@ -32,11 +32,11 @@
         "variant_label"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Fri Feb 18 16:16:09 2022 -0800",
-        "CV_collection_version":"6.2.56.10",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"ba0173c3a83bb3df5034bf2c5739cc0eb3237622",
+        "CV_collection_modified":"Wed Apr 13 13:21:31 2022 00100",
+        "CV_collection_version":"6.2.56.11",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"451e55b674be3fbab62dd8241840bbae237943bd",
         "required_global_attributes_CV_modified":"Thu Dec 19 15:32:17 2019 -0800",
         "required_global_attributes_CV_note":"Reverting addition of external_variables to required_global_attributes",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"

--- a/CMIP6_source_id.json
+++ b/CMIP6_source_id.json
@@ -7459,6 +7459,59 @@
             "release_year":"2018",
             "source_id":"UKESM1-0-MMh"
         },
+        "UKESM1-1-LL":{
+            "activity_participation":[
+                "CMIP",
+                "ScenarioMIP"
+            ],
+            "cohort":[
+                "Registered"
+            ],
+            "institution_id":[
+                "MOHC",
+                "NERC",
+                "NIMS-KMA",
+                "NIWA"
+            ],
+            "label":"UKESM1.1-LL",
+            "label_extended":"UKESM1.1-N96ORCA1",
+            "model_component":{
+                "aerosol":{
+                    "description":"UKCA-GLOMAP-mode",
+                    "native_nominal_resolution":"250 km"
+                },
+                "atmos":{
+                    "description":"MetUM-HadGEM3-GA7.1 (N96; 192 x 144 longitude/latitude; 85 levels; top level 85 km)",
+                    "native_nominal_resolution":"250 km"
+                },
+                "atmosChem":{
+                    "description":"UKCA-StratTrop",
+                    "native_nominal_resolution":"250 km"
+                },
+                "land":{
+                    "description":"JULES-ES-1.0",
+                    "native_nominal_resolution":"250 km"
+                },
+                "landIce":{
+                    "description":"none",
+                    "native_nominal_resolution":"none"
+                },
+                "ocean":{
+                    "description":"NEMO-HadGEM3-GO6.0 (eORCA1 tripolar primarily 1 deg with meridional refinement down to 1/3 degree in the tropics; 360 x 330 longitude/latitude; 75 levels; top grid cell 0-1 m)",
+                    "native_nominal_resolution":"100 km"
+                },
+                "ocnBgchem":{
+                    "description":"MEDUSA2",
+                    "native_nominal_resolution":"100 km"
+                },
+                "seaIce":{
+                    "description":"CICE-HadGEM3-GSI8 (eORCA1 tripolar primarily 1 deg; 360 x 330 longitude/latitude)",
+                    "native_nominal_resolution":"100 km"
+                }
+            },
+            "release_year":"2021",
+            "source_id":"UKESM1-1-LL"
+        },
         "UKESM1-ice-LL":{
             "activity_participation":[
                 "ISMIP6"
@@ -7614,13 +7667,13 @@
         }
     },
     "version_metadata":{
-        "CV_collection_modified":"Fri Feb 18 16:16:09 2022 -0800",
-        "CV_collection_version":"6.2.56.10",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"ba0173c3a83bb3df5034bf2c5739cc0eb3237622",
-        "source_id_CV_modified":"Fri Feb 18 10:30:58 2022 -0800",
-        "source_id_CV_note":"Revise source_id E3SM-1-0",
+        "CV_collection_modified":"Wed Apr 13 13:21:31 2022 00100",
+        "CV_collection_version":"6.2.56.11",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"451e55b674be3fbab62dd8241840bbae237943bd",
+        "source_id_CV_modified":"Fri Feb 18 16:16:09 2022 -0800",
+        "source_id_CV_note":"Add source_id UKESM1-1-LL",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_source_type.json
+++ b/CMIP6_source_type.json
@@ -12,11 +12,11 @@
         "SLAB":"slab-ocean used with an AGCM in representing the atmosphere-ocean coupled system"
     },
     "version_metadata":{
-        "CV_collection_modified":"Fri Feb 18 16:16:09 2022 -0800",
-        "CV_collection_version":"6.2.56.10",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"ba0173c3a83bb3df5034bf2c5739cc0eb3237622",
+        "CV_collection_modified":"Wed Apr 13 13:21:31 2022 00100",
+        "CV_collection_version":"6.2.56.11",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"451e55b674be3fbab62dd8241840bbae237943bd",
         "source_type_CV_modified":"Fri Sep 8 17:57:00 2017 -0700",
         "source_type_CV_note":"Issue396 durack1 augment source_type with description (#399)",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"

--- a/CMIP6_sub_experiment_id.json
+++ b/CMIP6_sub_experiment_id.json
@@ -76,11 +76,11 @@
         "s2029":"initialized near end of year 2029"
     },
     "version_metadata":{
-        "CV_collection_modified":"Fri Feb 18 16:16:09 2022 -0800",
-        "CV_collection_version":"6.2.56.10",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"ba0173c3a83bb3df5034bf2c5739cc0eb3237622",
+        "CV_collection_modified":"Wed Apr 13 13:21:31 2022 00100",
+        "CV_collection_version":"6.2.56.11",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"451e55b674be3fbab62dd8241840bbae237943bd",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)",
         "sub_experiment_id_CV_modified":"Mon Jun 17 11:01:51 2019 -0700",
         "sub_experiment_id_CV_note":"Revise sub_experiment_id values"

--- a/CMIP6_table_id.json
+++ b/CMIP6_table_id.json
@@ -45,11 +45,11 @@
         "fx"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Fri Feb 18 16:16:09 2022 -0800",
-        "CV_collection_version":"6.2.56.10",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"ba0173c3a83bb3df5034bf2c5739cc0eb3237622",
+        "CV_collection_modified":"Wed Apr 13 13:21:31 2022 00100",
+        "CV_collection_version":"6.2.56.11",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"451e55b674be3fbab62dd8241840bbae237943bd",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)",
         "table_id_CV_modified":"Fri Jan 13 09:27:00 2017 -0700",
         "table_id_CV_note":"Issue199 durack1 update table_id to Data Request v1.0 (#200)"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CMIP6_CVs [![stable version](https://img.shields.io/badge/Current%20version-6.2.56.10-brightgreen.svg)](https://github.com/WCRP-CMIP/CMIP6_CVs/releases/tag/6.2.56.10)
+# CMIP6_CVs [![stable version](https://img.shields.io/badge/Current%20version-6.2.56.11-brightgreen.svg)](https://github.com/WCRP-CMIP/CMIP6_CVs/releases/tag/6.2.56.11)
 
 Core Controlled Vocabularies (CVs) for use in CMIP6
 

--- a/docs/CMIP6_experiment_id.html
+++ b/docs/CMIP6_experiment_id.html
@@ -21,7 +21,7 @@ $(document).ready( function () {
 <title>CMIP6 experiment_id values</title>
 </head>
 <body>
-<p>WCRP-CMIP CMIP6_CVs version: 6.2.56.10</p>
+<p>WCRP-CMIP CMIP6_CVs version: 6.2.56.11</p>
 <table id="table_id" class="display compact" style="width:100%">
 <thead>
 <tr>

--- a/docs/CMIP6_institution_id.html
+++ b/docs/CMIP6_institution_id.html
@@ -21,7 +21,7 @@ $(document).ready( function () {
 <title>CMIP6 institution_id values</title>
 </head>
 <body>
-<p>WCRP-CMIP CMIP6_CVs version: 6.2.56.10</p>
+<p>WCRP-CMIP CMIP6_CVs version: 6.2.56.11</p>
 <table id="table_id" class="display compact" style="width:100%">
 <thead>
 <tr>

--- a/docs/CMIP6_source_id.html
+++ b/docs/CMIP6_source_id.html
@@ -21,7 +21,7 @@ $(document).ready( function () {
 <title>CMIP6 source_id values</title>
 </head>
 <body>
-<p>WCRP-CMIP CMIP6_CVs version: 6.2.56.10</p>
+<p>WCRP-CMIP CMIP6_CVs version: 6.2.56.11</p>
 <table id="table_id" class="display compact" style="width:100%">
 <thead>
 <tr>
@@ -2886,6 +2886,26 @@ $(document).ready( function () {
 <td>JULES-ES-1.0</td>
 <td>MEDUSA2 (horizontal resolution degraded relative to that used for ocean physics)</td>
 <td>CICE-HadGEM3-GSI8 (eORCA025 tripolar primarily 0.25 deg; 1440 x 1205 longitude/latitude)</td>
+</tr>
+<tr>
+<td>UKESM1-1-LL</td>
+<td>MOHC NERC NIMS-KMA NIWA</td>
+<td>2021</td>
+<td>CMIP ScenarioMIP</td>
+<td>Registered</td>
+<td>UKESM1.1-LL</td>
+<td>UKESM1.1-N96ORCA1</td>
+<td>MetUM-HadGEM3-GA7.1 (N96; 192 x 144 longitude/latitude; 85 levels; top level 85 km)</td>
+<td>250 km</td>
+<td>NEMO-HadGEM3-GO6.0 (eORCA1 tripolar primarily 1 deg with meridional refinement down to 1/3 degree in the tropics; 360 x 330 longitude/latitude; 75 levels; top grid cell 0-1 m)</td>
+<td>100 km</td>
+<td>none</td>
+<td>none</td>
+<td>UKCA-GLOMAP-mode</td>
+<td>UKCA-StratTrop</td>
+<td>JULES-ES-1.0</td>
+<td>MEDUSA2</td>
+<td>CICE-HadGEM3-GSI8 (eORCA1 tripolar primarily 1 deg; 360 x 330 longitude/latitude)</td>
 </tr>
 <tr>
 <td>UKESM1-ice-LL</td>

--- a/mip_era.json
+++ b/mip_era.json
@@ -7,13 +7,13 @@
         "CMIP6"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Fri Feb 18 16:16:09 2022 -0800",
-        "CV_collection_version":"6.2.56.10",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
+        "CV_collection_modified":"Wed Apr 13 13:21:31 2022 00100",
+        "CV_collection_version":"6.2.56.11",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
         "mip_era_CV_modified":"Thu Aug 25 17:21:00 2016 -0700",
         "mip_era_CV_note":"Fix #36 - Add CV name to json structure",
-        "previous_commit":"ba0173c3a83bb3df5034bf2c5739cc0eb3237622",
+        "previous_commit":"451e55b674be3fbab62dd8241840bbae237943bd",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/src/CMIP6Lib.py
+++ b/src/CMIP6Lib.py
@@ -131,7 +131,7 @@ def versionHistoryUpdate(key,commitMessage,timeStamp,MD5,versionHistory):
 
 #%% Clean functions
 def cleanString(string):
-    if isinstance(string,str) or isinstance(string,unicode):
+    if isinstance(string,str): # or isinstance(string,unicode):
     # Take a string and clean it for standard errors
         string = string.strip()  # Remove trailing whitespace
         string = string.strip(',.')  # Remove trailing characters

--- a/src/versionHistory.json
+++ b/src/versionHistory.json
@@ -61,10 +61,10 @@
             "timeStamp":"Thu Dec 19 15:32:17 2019 -0800"
         },
         "source_id":{
-            "MD5":"ba0173c3a83bb3df5034bf2c5739cc0eb3237622",
-            "URL":"https://github.com/WCRP-CMIP/CMIP6_CVs/commit/ba0173c3a83bb3df5034bf2c5739cc0eb3237622",
-            "commitMessage":"Revise source_id E3SM-1-0",
-            "timeStamp":"Fri Feb 18 16:16:09 2022 -0800"
+            "MD5":"451e55b674be3fbab62dd8241840bbae237943bd",
+            "URL":"https://github.com/WCRP-CMIP/CMIP6_CVs/commit/451e55b674be3fbab62dd8241840bbae237943bd",
+            "commitMessage":"Add source_id UKESM1-1-LL",
+            "timeStamp":"Wed Apr 13 13:21:31 2022 00100"
         },
         "source_type":{
             "MD5":"fa3f07e9c215b35e0a54737acba2c2a9f6b8901f",
@@ -85,7 +85,7 @@
             "timeStamp":"Fri Jan 13 09:27:00 2017 -0700"
         },
         "versions":{
-            "versionCVCommit":10,
+            "versionCVCommit":11,
             "versionCVContent":56,
             "versionCVStructure":2,
             "versionMIPEra":6

--- a/src/writeJson.py
+++ b/src/writeJson.py
@@ -572,11 +572,11 @@ sys.path.insert(0, '~/sync/git/durolib/durolib')  # trustym
 #from unidecode import unidecode
 
 # %% Set commit message and author info
-commitMessage = '\"Revise source_id E3SM-1-0\"'
-#author = 'Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>'
-#author_institution_id = 'MOHC'
-author = 'Paul J. Durack <durack1@llnl.gov>'
-author_institution_id = 'PCMDI'
+commitMessage = '\"Add source_id UKESM1-1-LL\"'
+author = 'Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>'
+author_institution_id = 'MOHC'
+#author = 'Paul J. Durack <durack1@llnl.gov>'
+#author_institution_id = 'PCMDI'
 
 # %% List target controlled vocabularies (CVs)
 masterTargets = [
@@ -1013,10 +1013,14 @@ source_id = source_id.get('source_id')  # Fudge to extract duplicate level
 del(tmp)
 
 # Fix issues
-key = "E3SM-1-0"
-source_id[key]['activity_participation'].append("DAMIP")
-source_id[key]['activity_participation'].sort()
-
+key = 'UKESM1-1-LL'
+from copy import copy
+source_id[key] = copy(source_id['UKESM1-0-LL'])
+source_id[key]['activity_participation'] = ['CMIP', 'ScenarioMIP']
+source_id[key]['label'] = 'UKESM1.1-LL'
+source_id[key]['label_extended'] = 'UKESM1.1-N96ORCA1'
+source_id[key]['release_year'] = '2021'
+source_id[key]['source_id'] = 'UKESM1-1-LL'
 # Example
 # key = 'GISS-E2-2-H'
 # source_id[key] = {}


### PR DESCRIPTION
Adds UKESM1-1-LL for #1060 

Note that I had to make a minor change to CMIP6Lib.py to remove an `isinstance` call that was comparing an object to the `unicode` class which doesn't exist in later versions of python3.  I'll have a think about putting together a conda environment file for this repo to ensure we have a consistent set of libraries/python versions.

