### PR TITLE
Update published source_id entries with rights; augment license

### DIFF
--- a/CMIP6_activity_id.json
+++ b/CMIP6_activity_id.json
@@ -26,13 +26,13 @@
         "VolMIP":"Volcanic Forcings Model Intercomparison Project"
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
+        "CV_collection_modified":"Wed May 25 13:56:09 2022 00100",
+        "CV_collection_version":"6.2.57.1",
         "activity_id_CV_modified":"Mon Mar  5 16:39:09 2018 -0800",
         "activity_id_CV_note":"Update activity_id to include CDRMIP and PAMIP",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_experiment_id.json
+++ b/CMIP6_experiment_id.json
@@ -9456,13 +9456,13 @@
         }
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
+        "CV_collection_modified":"Wed May 25 13:56:09 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "experiment_id_CV_modified":"Tue Dec 15 12:25:59 2020 -0800",
         "experiment_id_CV_note":"Revise experiment_id historical parent experiments",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_frequency.json
+++ b/CMIP6_frequency.json
@@ -18,13 +18,13 @@
         "yrPt":"sampled yearly, at specified time point within the time period"
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
+        "CV_collection_modified":"Wed May 25 13:56:09 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "frequency_CV_modified":"Mon May 24 13:48:15 2021 00100",
         "frequency_CV_note":"Update description of 3hr and 6hr frequencies",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_grid_label.json
+++ b/CMIP6_grid_label.json
@@ -47,13 +47,13 @@
         "grz":"regridded zonal mean data reported on the data provider's preferred latitude target grid"
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
+        "CV_collection_modified":"Wed May 25 13:56:09 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "grid_label_CV_modified":"Fri Sep 8 18:12:00 2017 -0700",
         "grid_label_CV_note":"Issue395 durack1 augment grid_label with description (#401)",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_institution_id.json
+++ b/CMIP6_institution_id.json
@@ -55,13 +55,13 @@
         "UofT":"Department of Physics, University of Toronto, 60 St George Street, Toronto, ON M5S1A7, Canada"
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
+        "CV_collection_modified":"Wed May 25 13:56:09 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
         "institution_id_CV_modified":"Mon Nov 16 11:16:39 2020 -0800",
         "institution_id_CV_note":"Register institution_id LLNL; Py3 cleanup",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_license.json
+++ b/CMIP6_license.json
@@ -21,13 +21,13 @@
         }
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "license_CV_modified":"Mon Feb 27 10:30:00 2017 -0700",
+        "CV_collection_modified":"Wed May 25 13:56:09 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "license_CV_modified":"Tue May 24 11:20:06 2022 -0700",
         "license_CV_note":"Update published source_id entries with rights; augment license",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_nominal_resolution.json
+++ b/CMIP6_nominal_resolution.json
@@ -17,13 +17,13 @@
         "5000 km"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
+        "CV_collection_modified":"Wed May 25 13:56:09 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
         "nominal_resolution_CV_modified":"Tues Nov 15 16:04:00 2016 -0700",
         "nominal_resolution_CV_note":"Issue141 durack1 update grid_resolution to nominal_resolution (#143)",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_realm.json
+++ b/CMIP6_realm.json
@@ -10,11 +10,11 @@
         "seaIce":"Sea Ice"
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "CV_collection_modified":"Wed May 25 13:56:09 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "realm_CV_modified":"Tues Apr 18 12:03:00 2017 -0700",
         "realm_CV_note":"Issue285 durack1 update realm format (#290)",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"

--- a/CMIP6_required_global_attributes.json
+++ b/CMIP6_required_global_attributes.json
@@ -32,11 +32,11 @@
         "variant_label"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "CV_collection_modified":"Wed May 25 13:56:09 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "required_global_attributes_CV_modified":"Thu Dec 19 15:32:17 2019 -0800",
         "required_global_attributes_CV_note":"Reverting addition of external_variables to required_global_attributes",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"

--- a/CMIP6_source_id.json
+++ b/CMIP6_source_id.json
@@ -615,6 +615,13 @@
             ],
             "label":"AWI-ESM 2.1 LR",
             "label_extended":"AWI-ESM 2.1 LR",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"none",
@@ -848,6 +855,13 @@
             ],
             "label":"BESM 2.9",
             "label_extended":"BESM 2.9",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"none",
@@ -905,6 +919,13 @@
             ],
             "label":"BNU-ESM 1.1",
             "label_extended":"BNU-ESM 1.1",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"CAM-chem; semi-interactive",
@@ -954,6 +975,13 @@
             ],
             "label":"CAM-MPAS-HR",
             "label_extended":"CAM MPAS (Community Atmosphere Model - Model for Prediction Across Scales)",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"none, prescribed MACv2-SP",
@@ -1003,6 +1031,13 @@
             ],
             "label":"CAM-MPAS-LR",
             "label_extended":"CAM MPAS (Community Atmosphere Model - Model for Prediction Across Scales)",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"none, prescribed MACv2-SP",
@@ -1557,6 +1592,13 @@
             ],
             "label":"CESM2-SE",
             "label_extended":"CESM2-SE spectral element (cubed-sphere grid)",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"MAM4 (same grid as atmos)",
@@ -2230,6 +2272,13 @@
             ],
             "label":"CNRM-ESM2-1-HR",
             "label_extended":"CNRM-ESM2-1-HR",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"TACTIC_v2",
@@ -2280,6 +2329,13 @@
             ],
             "label":"CSIRO Mk3L 1.3",
             "label_extended":"CSIRO Mk3L 1.3",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"none",
@@ -2846,6 +2902,13 @@
             ],
             "label":"EC-Earth3-GrIS",
             "label_extended":"EC-Earth3-GrIS",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"none",
@@ -2897,6 +2960,13 @@
             ],
             "label":"EC-Earth3-HR",
             "label_extended":"EC-Earth3-HR",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"none",
@@ -3469,6 +3539,13 @@
             ],
             "label":"EMAC-2-53-Vol",
             "label_extended":"EMAC-2-53-x-Vol",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"gmxe 2.2.x",
@@ -3519,6 +3596,13 @@
             ],
             "label":"EMAC-2-54-AerChem",
             "label_extended":"EMAC-2-54-x-AerChem",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"gmxe 2.2.x",
@@ -4123,6 +4207,13 @@
             ],
             "label":"GFDL-GLOBAL-LBL",
             "label_extended":"GFDL Reference Forward Model Line-by-Line with DA/DISORT solver (March 2019)",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"none",
@@ -5632,6 +5723,13 @@
             ],
             "label":"IPSL-CM6A-ATM-ICO-HR",
             "label_extended":"IPSL-CM6A-ATM-ICO-HR",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"none",
@@ -5679,6 +5777,13 @@
             ],
             "label":"IPSL-CM6A-ATM-ICO-LR",
             "label_extended":"IPSL-CM6A-ATM-ICO-LR",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"none",
@@ -5726,6 +5831,13 @@
             ],
             "label":"IPSL-CM6A-ATM-ICO-MR",
             "label_extended":"IPSL-CM6A-ATM-ICO-MR",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"none",
@@ -5773,6 +5885,13 @@
             ],
             "label":"IPSL-CM6A-ATM-ICO-VHR",
             "label_extended":"IPSL-CM6A-ATM-ICO-VHR",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"none",
@@ -5822,6 +5941,13 @@
             ],
             "label":"IPSL-CM6A-ATM-LR-REPROBUS",
             "label_extended":"IPSL-CM6A-ATM-LR-REPROBUS",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"LMDZ (NPv6 ; 144 x 143 longitude/latitude; 79 levels; top level 80000 m)",
@@ -6003,6 +6129,13 @@
             ],
             "label":"IPSL-CM6A-MR025",
             "label_extended":"IPSL-CM6A-MR025",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"none",
@@ -6052,6 +6185,13 @@
             ],
             "label":"IPSL-CM6A-MR1",
             "label_extended":"IPSL-CM6A-MR1",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"none",
@@ -7236,6 +7376,13 @@
             ],
             "label":"NICAM16-9D-L78",
             "label_extended":"NICAM.16 gl09-L78 with NDW6",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"Prescribed MACv2-SP",
@@ -7461,6 +7608,13 @@
             ],
             "label":"NorESM2-HH",
             "label_extended":"NorESM2-HH (high atmosphere-high ocean resolution, GHG concentration driven)",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"OsloAero",
@@ -7584,6 +7738,13 @@
             ],
             "label":"NorESM2-LME",
             "label_extended":"NorESM2-LME (low atmosphere-medium ocean resolution, GHG emission driven)",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"OsloAero",
@@ -7634,6 +7795,13 @@
             ],
             "label":"NorESM2-LMEC",
             "label_extended":"NorESM2-LMEC (low atmosphere-medium ocean resolution, GHG emission driven, complex atmospheric chemistry)",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"OsloAero",
@@ -7689,6 +7857,13 @@
             ],
             "label":"NorESM2-MH",
             "label_extended":"NorESM2-MH (medium atmosphere-high ocean resolution, GHG concentration driven)",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"OsloAero",
@@ -7801,6 +7976,13 @@
             ],
             "label":"PCMDI-test 1.0",
             "label_extended":"PCMDI-test 1.0 (This entry is free text for users to contribute verbose information)",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"none",
@@ -8335,6 +8517,13 @@
             ],
             "label":"UKESM1.1-LL",
             "label_extended":"UKESM1.1-N96ORCA1",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"UKCA-GLOMAP-mode",
@@ -8443,6 +8632,13 @@
             ],
             "label":"UofT-CCSM4",
             "label_extended":"The NCAR CCSM4 model with the ocean component run in a non-default configuration (the University of Toronto configuration) where tidal mixing and overflow parametrizations are turned off. The vertical profile of ocean diapycnal diffusivity is fixed to the POP1 profile used in CCSM3. See Peltier and Vettoretti, 2014 GRL (https://doi.org/10.1002/2014GL061413), Chandan and Peltier, 2017 Clim. Past. (https://doi.org/10.5194/cp-13-919-2017)",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"unnamed",
@@ -8496,6 +8692,13 @@
             ],
             "label":"VRESM 1.0",
             "label_extended":"VRESM 1.0 (Variable-resolution Earth System Model 1.0)",
+            "license_info":{
+                "exceptions_contact":"",
+                "history":"",
+                "id":"",
+                "license":"",
+                "url":""
+            },
             "model_component":{
                 "aerosol":{
                     "description":"Rotstayn-1.0",
@@ -8535,13 +8738,13 @@
         }
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
-        "source_id_CV_modified":"Mon May 23 13:59:29 2022 00100",
-        "source_id_CV_note":"Remove source_id UKESM1-0-MMh",
+        "CV_collection_modified":"Wed May 25 13:56:09 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+        "source_id_CV_modified":"Tue May 24 11:20:06 2022 -0700",
+        "source_id_CV_note":"Update published source_id entries with rights; augment license",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_source_type.json
+++ b/CMIP6_source_type.json
@@ -12,11 +12,11 @@
         "SLAB":"slab-ocean used with an AGCM in representing the atmosphere-ocean coupled system"
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "CV_collection_modified":"Wed May 25 13:56:09 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "source_type_CV_modified":"Fri Sep 8 17:57:00 2017 -0700",
         "source_type_CV_note":"Issue396 durack1 augment source_type with description (#399)",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"

--- a/CMIP6_sub_experiment_id.json
+++ b/CMIP6_sub_experiment_id.json
@@ -76,11 +76,11 @@
         "s2029":"initialized near end of year 2029"
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "CV_collection_modified":"Wed May 25 13:56:09 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)",
         "sub_experiment_id_CV_modified":"Mon Jun 17 11:01:51 2019 -0700",
         "sub_experiment_id_CV_note":"Revise sub_experiment_id values"

--- a/CMIP6_table_id.json
+++ b/CMIP6_table_id.json
@@ -45,11 +45,11 @@
         "fx"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "CV_collection_modified":"Wed May 25 13:56:09 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)",
         "table_id_CV_modified":"Fri Jan 13 09:27:00 2017 -0700",
         "table_id_CV_note":"Issue199 durack1 update table_id to Data Request v1.0 (#200)"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CMIP6_CVs [![stable version](https://img.shields.io/badge/Current%20version-6.2.57.0-brightgreen.svg)](https://github.com/WCRP-CMIP/CMIP6_CVs/releases/tag/6.2.57.0)
+# CMIP6_CVs [![stable version](https://img.shields.io/badge/Current%20version-6.2.57.1-brightgreen.svg)](https://github.com/WCRP-CMIP/CMIP6_CVs/releases/tag/6.2.57.1)
 
 Core Controlled Vocabularies (CVs) for use in CMIP6
 

--- a/docs/CMIP6_experiment_id.html
+++ b/docs/CMIP6_experiment_id.html
@@ -21,7 +21,7 @@ $(document).ready( function () {
 <title>CMIP6 experiment_id values</title>
 </head>
 <body>
-<p>WCRP-CMIP CMIP6_CVs version: 6.2.57.0</p>
+<p>WCRP-CMIP CMIP6_CVs version: 6.2.57.1</p>
 <table id="table_id" class="display compact" style="width:100%">
 <thead>
 <tr>

--- a/docs/CMIP6_institution_id.html
+++ b/docs/CMIP6_institution_id.html
@@ -21,7 +21,7 @@ $(document).ready( function () {
 <title>CMIP6 institution_id values</title>
 </head>
 <body>
-<p>WCRP-CMIP CMIP6_CVs version: 6.2.57.0</p>
+<p>WCRP-CMIP CMIP6_CVs version: 6.2.57.1</p>
 <table id="table_id" class="display compact" style="width:100%">
 <thead>
 <tr>

--- a/docs/CMIP6_source_id.html
+++ b/docs/CMIP6_source_id.html
@@ -21,7 +21,7 @@ $(document).ready( function () {
 <title>CMIP6 source_id values</title>
 </head>
 <body>
-<p>WCRP-CMIP CMIP6_CVs version: 6.2.57.0</p>
+<p>WCRP-CMIP CMIP6_CVs version: 6.2.57.1</p>
 <table id="table_id" class="display compact" style="width:100%">
 <thead>
 <tr>

--- a/docs/CMIP6_source_id_licenses.html
+++ b/docs/CMIP6_source_id_licenses.html
@@ -21,7 +21,7 @@ $(document).ready( function () {
         <title>CMIP6 source_id license details</title>
 </head>
 <body>
-        <p>WCRP-CMIP CMIP6_CVs version: 6.2.57.0</p>
+        <p>WCRP-CMIP CMIP6_CVs version: 6.2.57.1</p>
         <table id="table_id" class="display compact" style="width:100%">
 
         <thead><tr>

--- a/mip_era.json
+++ b/mip_era.json
@@ -7,13 +7,13 @@
         "CMIP6"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
+        "CV_collection_modified":"Wed May 25 13:56:09 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
         "mip_era_CV_modified":"Thu Aug 25 17:21:00 2016 -0700",
         "mip_era_CV_note":"Fix #36 - Add CV name to json structure",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/src/jsonToHtml.py
+++ b/src/jsonToHtml.py
@@ -331,8 +331,8 @@ with open(fout, 'w') as fh_license:
                 cell_data = ' '.join(cell_data)
             row.append(cell_data)
         # try to get license header, otherwise leave blanks
-        try:
-            license_data = source_id_data['license_info']
+        license_data = source_id_data['license_info']
+        if license_data['id']:
             license = '<a href="{url}">{id}</a>'.format(**license_data)
             contact = license_data['exceptions_contact']
             history = license_data['history']
@@ -340,8 +340,7 @@ with open(fout, 'w') as fh_license:
             if specific_info.startswith('http'):
                 specific_info = '<a href="{0}">{0}</a>'.format(specific_info)
             row += [license, contact, history, specific_info]
-
-        except KeyError:
+        else:
             row += [''] * len(license_headings)
         fh_license.write(
             '<tr>\n' +

--- a/src/versionHistory.json
+++ b/src/versionHistory.json
@@ -61,10 +61,10 @@
             "timeStamp":"Thu Dec 19 15:32:17 2019 -0800"
         },
         "source_id":{
-            "MD5":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
-            "URL":"https://github.com/WCRP-CMIP/CMIP6_CVs/commit/9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+            "MD5":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+            "URL":"https://github.com/WCRP-CMIP/CMIP6_CVs/commit/bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
             "commitMessage":"Update published source_id entries with rights; augment license",
-            "timeStamp":"Tue May 24 11:20:06 2022 -0700"
+            "timeStamp":"Wed May 25 13:56:09 2022 00100"
         },
         "source_type":{
             "MD5":"fa3f07e9c215b35e0a54737acba2c2a9f6b8901f",
@@ -85,7 +85,7 @@
             "timeStamp":"Fri Jan 13 09:27:00 2017 -0700"
         },
         "versions":{
-            "versionCVCommit":0,
+            "versionCVCommit":1,
             "versionCVContent":57,
             "versionCVStructure":2,
             "versionMIPEra":6

--- a/src/writeJson.py
+++ b/src/writeJson.py
@@ -570,6 +570,8 @@ PJD 24 May 2022    - Update with master; tweak license https://github.com/WCRP-C
 PJD 24 May 2022    - Update source_id license info following https://github.com/WCRP-CMIP/CMIP6_CVs/pull/1069/files
                      - TODO: Review all start/end_year pairs for experiments https://github.com/WCRP-CMIP/CMIP6_CVs/issues/845
                      - TODO: Generate table_id from dataRequest https://github.com/WCRP-CMIP/CMIP6_CVs/issues/166
+MSM 24 May 2022    - Added prototype license table
+MSM 25 May 2022    - Added blank license info for unpublished source_ids
 @author: durack1
 """
 
@@ -585,10 +587,10 @@ except ImportError:
 
 # %% Set commit message and author info
 commitMessage = '\"Update published source_id entries with rights; augment license\"'
-#author = 'Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>'
-#author_institution_id = 'MOHC'
-author = 'Paul J. Durack <durack1@llnl.gov>'
-author_institution_id = 'PCMDI'
+author = 'Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>'
+author_institution_id = 'MOHC'
+#author = 'Paul J. Durack <durack1@llnl.gov>'
+#author_institution_id = 'PCMDI'
 
 # %% List target controlled vocabularies (CVs)
 masterTargets = [
@@ -1039,24 +1041,35 @@ source_id = source_id.get('source_id')  # Fudge to extract duplicate level
 del(tmp)
 
 # Fix issues
-f = "220524_CMIP6-CMIP_mergedMetadata.json"
-counter = 1
-with open(f) as fh:
-    rightsMeta = json.load(fh)
-# Loop through entries and add to source_id
-for count, srcId in enumerate(rightsMeta.keys()):
-    if "license_info" in rightsMeta[srcId].keys():
-        print(count, srcId, "found")
-        # add rights
-        source_id[srcId]["license_info"] = {}
-        source_id[srcId]["license_info"] = rightsMeta[srcId]["license_info"]
-        # toggle cohort
-        source_id[srcId]["cohort"] = ["Published"]
-    else:
-        print("----------")
-        print(count, counter, srcId, "not found")
-        counter = counter+1
-del(rightsMeta)
+# add blank license_info
+for entry, entry_data in source_id.items():
+    if 'license_info' not in entry_data:
+        entry_data['license_info'] = {
+            'exceptions_contact': '',
+            'history': '',
+            'id': '',
+            'license': '',
+            'url': '',
+        }
+
+# f = "220519_CMIP6-CMIP_mergedMetadata.json"
+# counter = 1
+# with open(f) as fh:
+#     rightsMeta = json.load(fh)
+# # Loop through entries and add to source_id
+# for count, srcId in enumerate(rightsMeta.keys()):
+#     if "license_info" in rightsMeta[srcId].keys():
+#         print(count, srcId, "found")
+#         # add rights
+#         source_id[srcId]["license_info"] = {}
+#         source_id[srcId]["license_info"] = rightsMeta[srcId]["license_info"]
+#         # toggle cohort
+#         source_id[srcId]["cohort"] = ["Published"]
+#     else:
+#         print("----------")
+#         print(count, counter, srcId, "not found")
+#         counter = counter+1
+# del(rightsMeta)
 
 # Example
 # key = 'GISS-E2-2-H'


### PR DESCRIPTION
Added blank `license_info` dictionaries to the 29 source ids that are `Registered` but not `Published`.
