### PR TITLE
Update UKESM1-1-LL publication status and license info

### DIFF
--- a/CMIP6_activity_id.json
+++ b/CMIP6_activity_id.json
@@ -26,13 +26,13 @@
         "VolMIP":"Volcanic Forcings Model Intercomparison Project"
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
+        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_version":"6.2.57.1",
         "activity_id_CV_modified":"Mon Mar  5 16:39:09 2018 -0800",
         "activity_id_CV_note":"Update activity_id to include CDRMIP and PAMIP",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_activity_id.json
+++ b/CMIP6_activity_id.json
@@ -26,13 +26,13 @@
         "VolMIP":"Volcanic Forcings Model Intercomparison Project"
     },
     "version_metadata":{
-        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_modified":"Thu May 26 11:27:09 2022 -0700",
         "CV_collection_version":"6.2.57.1",
         "activity_id_CV_modified":"Mon Mar  5 16:39:09 2018 -0800",
         "activity_id_CV_note":"Update activity_id to include CDRMIP and PAMIP",
         "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "institution_id":"MOHC",
-        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+        "previous_commit":"3c94649865cf3770f32a645212cfc8a6b946e434",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_experiment_id.json
+++ b/CMIP6_experiment_id.json
@@ -9456,13 +9456,13 @@
         }
     },
     "version_metadata":{
-        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_modified":"Thu May 26 11:27:09 2022 -0700",
         "CV_collection_version":"6.2.57.1",
         "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "experiment_id_CV_modified":"Tue Dec 15 12:25:59 2020 -0800",
         "experiment_id_CV_note":"Revise experiment_id historical parent experiments",
         "institution_id":"MOHC",
-        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+        "previous_commit":"3c94649865cf3770f32a645212cfc8a6b946e434",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_experiment_id.json
+++ b/CMIP6_experiment_id.json
@@ -9456,13 +9456,13 @@
         }
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
+        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "experiment_id_CV_modified":"Tue Dec 15 12:25:59 2020 -0800",
         "experiment_id_CV_note":"Revise experiment_id historical parent experiments",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_frequency.json
+++ b/CMIP6_frequency.json
@@ -18,13 +18,13 @@
         "yrPt":"sampled yearly, at specified time point within the time period"
     },
     "version_metadata":{
-        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_modified":"Thu May 26 11:27:09 2022 -0700",
         "CV_collection_version":"6.2.57.1",
         "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "frequency_CV_modified":"Mon May 24 13:48:15 2021 00100",
         "frequency_CV_note":"Update description of 3hr and 6hr frequencies",
         "institution_id":"MOHC",
-        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+        "previous_commit":"3c94649865cf3770f32a645212cfc8a6b946e434",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_frequency.json
+++ b/CMIP6_frequency.json
@@ -18,13 +18,13 @@
         "yrPt":"sampled yearly, at specified time point within the time period"
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
+        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "frequency_CV_modified":"Mon May 24 13:48:15 2021 00100",
         "frequency_CV_note":"Update description of 3hr and 6hr frequencies",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_grid_label.json
+++ b/CMIP6_grid_label.json
@@ -47,13 +47,13 @@
         "grz":"regridded zonal mean data reported on the data provider's preferred latitude target grid"
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
+        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "grid_label_CV_modified":"Fri Sep 8 18:12:00 2017 -0700",
         "grid_label_CV_note":"Issue395 durack1 augment grid_label with description (#401)",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_grid_label.json
+++ b/CMIP6_grid_label.json
@@ -47,13 +47,13 @@
         "grz":"regridded zonal mean data reported on the data provider's preferred latitude target grid"
     },
     "version_metadata":{
-        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_modified":"Thu May 26 11:27:09 2022 -0700",
         "CV_collection_version":"6.2.57.1",
         "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "grid_label_CV_modified":"Fri Sep 8 18:12:00 2017 -0700",
         "grid_label_CV_note":"Issue395 durack1 augment grid_label with description (#401)",
         "institution_id":"MOHC",
-        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+        "previous_commit":"3c94649865cf3770f32a645212cfc8a6b946e434",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_institution_id.json
+++ b/CMIP6_institution_id.json
@@ -55,13 +55,13 @@
         "UofT":"Department of Physics, University of Toronto, 60 St George Street, Toronto, ON M5S1A7, Canada"
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
+        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
         "institution_id_CV_modified":"Mon Nov 16 11:16:39 2020 -0800",
         "institution_id_CV_note":"Register institution_id LLNL; Py3 cleanup",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_institution_id.json
+++ b/CMIP6_institution_id.json
@@ -55,13 +55,13 @@
         "UofT":"Department of Physics, University of Toronto, 60 St George Street, Toronto, ON M5S1A7, Canada"
     },
     "version_metadata":{
-        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_modified":"Thu May 26 11:27:09 2022 -0700",
         "CV_collection_version":"6.2.57.1",
         "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "institution_id":"MOHC",
         "institution_id_CV_modified":"Mon Nov 16 11:16:39 2020 -0800",
         "institution_id_CV_note":"Register institution_id LLNL; Py3 cleanup",
-        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+        "previous_commit":"3c94649865cf3770f32a645212cfc8a6b946e434",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_license.json
+++ b/CMIP6_license.json
@@ -21,13 +21,13 @@
         }
     },
     "version_metadata":{
-        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_modified":"Thu May 26 11:27:09 2022 -0700",
         "CV_collection_version":"6.2.57.1",
         "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "institution_id":"MOHC",
         "license_CV_modified":"Tue May 24 11:20:06 2022 -0700",
         "license_CV_note":"Update published source_id entries with rights; augment license",
-        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+        "previous_commit":"3c94649865cf3770f32a645212cfc8a6b946e434",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_license.json
+++ b/CMIP6_license.json
@@ -21,13 +21,13 @@
         }
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "license_CV_modified":"Mon Feb 27 10:30:00 2017 -0700",
+        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "license_CV_modified":"Tue May 24 11:20:06 2022 -0700",
         "license_CV_note":"Update published source_id entries with rights; augment license",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_nominal_resolution.json
+++ b/CMIP6_nominal_resolution.json
@@ -17,13 +17,13 @@
         "5000 km"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
+        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
         "nominal_resolution_CV_modified":"Tues Nov 15 16:04:00 2016 -0700",
         "nominal_resolution_CV_note":"Issue141 durack1 update grid_resolution to nominal_resolution (#143)",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_nominal_resolution.json
+++ b/CMIP6_nominal_resolution.json
@@ -17,13 +17,13 @@
         "5000 km"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_modified":"Thu May 26 11:27:09 2022 -0700",
         "CV_collection_version":"6.2.57.1",
         "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "institution_id":"MOHC",
         "nominal_resolution_CV_modified":"Tues Nov 15 16:04:00 2016 -0700",
         "nominal_resolution_CV_note":"Issue141 durack1 update grid_resolution to nominal_resolution (#143)",
-        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+        "previous_commit":"3c94649865cf3770f32a645212cfc8a6b946e434",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_realm.json
+++ b/CMIP6_realm.json
@@ -10,11 +10,11 @@
         "seaIce":"Sea Ice"
     },
     "version_metadata":{
-        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_modified":"Thu May 26 11:27:09 2022 -0700",
         "CV_collection_version":"6.2.57.1",
         "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "institution_id":"MOHC",
-        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+        "previous_commit":"3c94649865cf3770f32a645212cfc8a6b946e434",
         "realm_CV_modified":"Tues Apr 18 12:03:00 2017 -0700",
         "realm_CV_note":"Issue285 durack1 update realm format (#290)",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"

--- a/CMIP6_realm.json
+++ b/CMIP6_realm.json
@@ -10,11 +10,11 @@
         "seaIce":"Sea Ice"
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "realm_CV_modified":"Tues Apr 18 12:03:00 2017 -0700",
         "realm_CV_note":"Issue285 durack1 update realm format (#290)",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"

--- a/CMIP6_required_global_attributes.json
+++ b/CMIP6_required_global_attributes.json
@@ -32,11 +32,11 @@
         "variant_label"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_modified":"Thu May 26 11:27:09 2022 -0700",
         "CV_collection_version":"6.2.57.1",
         "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "institution_id":"MOHC",
-        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+        "previous_commit":"3c94649865cf3770f32a645212cfc8a6b946e434",
         "required_global_attributes_CV_modified":"Thu Dec 19 15:32:17 2019 -0800",
         "required_global_attributes_CV_note":"Reverting addition of external_variables to required_global_attributes",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"

--- a/CMIP6_required_global_attributes.json
+++ b/CMIP6_required_global_attributes.json
@@ -32,11 +32,11 @@
         "variant_label"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "required_global_attributes_CV_modified":"Thu Dec 19 15:32:17 2019 -0800",
         "required_global_attributes_CV_note":"Reverting addition of external_variables to required_global_attributes",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"

--- a/CMIP6_source_id.json
+++ b/CMIP6_source_id.json
@@ -8337,7 +8337,7 @@
             "label_extended":"UKESM1.1-N96ORCA1",
             "license_info":{
                 "exceptions_contact":"@metoffice.gov.uk <- cmip6.ukesm1",
-                "history":"2022-05-04: initially published under CC BY-SA 4.0; 2021-11-15: relaxed to CC BY 4.0",
+                "history":"2022-05-04: initially published under CC BY-SA 4.0; 2022-05-04: relaxed to CC BY 4.0",
                 "id":"CC BY 4.0",
                 "license":"Creative Commons Attribution 4.0 International License (CC BY 4.0; https://creativecommons.org/licenses/by/4.0/)",
                 "source_specific_info":"https://ukesm.ac.uk/licensing-of-met-office-nerc-and-niwa-cmip6-data/",
@@ -8543,11 +8543,11 @@
         }
     },
     "version_metadata":{
-        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_modified":"Thu May 26 11:27:09 2022 -0700",
         "CV_collection_version":"6.2.57.1",
         "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "institution_id":"MOHC",
-        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+        "previous_commit":"3c94649865cf3770f32a645212cfc8a6b946e434",
         "source_id_CV_modified":"Tue May 24 11:20:06 2022 -0700",
         "source_id_CV_note":"Update UKESM1-1-LL publication status and license info",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"

--- a/CMIP6_source_id.json
+++ b/CMIP6_source_id.json
@@ -8325,7 +8325,7 @@
                 "ScenarioMIP"
             ],
             "cohort":[
-                "Registered"
+                "Published"
             ],
             "institution_id":[
                 "MOHC",
@@ -8335,6 +8335,14 @@
             ],
             "label":"UKESM1.1-LL",
             "label_extended":"UKESM1.1-N96ORCA1",
+            "license_info":{
+                "exceptions_contact":"@metoffice.gov.uk <- cmip6.ukesm1",
+                "history":"2022-05-04: initially published under CC BY-SA 4.0; 2021-11-15: relaxed to CC BY 4.0",
+                "id":"CC BY 4.0",
+                "license":"Creative Commons Attribution 4.0 International License (CC BY 4.0; https://creativecommons.org/licenses/by/4.0/)",
+                "source_specific_info":"https://ukesm.ac.uk/licensing-of-met-office-nerc-and-niwa-cmip6-data/",
+                "url":"https://creativecommons.org/licenses/by/4.0/"
+            },
             "model_component":{
                 "aerosol":{
                     "description":"UKCA-GLOMAP-mode",
@@ -8535,13 +8543,13 @@
         }
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
-        "source_id_CV_modified":"Mon May 23 13:59:29 2022 00100",
-        "source_id_CV_note":"Remove source_id UKESM1-0-MMh",
+        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+        "source_id_CV_modified":"Tue May 24 11:20:06 2022 -0700",
+        "source_id_CV_note":"Update UKESM1-1-LL publication status and license info",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/CMIP6_source_type.json
+++ b/CMIP6_source_type.json
@@ -12,11 +12,11 @@
         "SLAB":"slab-ocean used with an AGCM in representing the atmosphere-ocean coupled system"
     },
     "version_metadata":{
-        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_modified":"Thu May 26 11:27:09 2022 -0700",
         "CV_collection_version":"6.2.57.1",
         "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "institution_id":"MOHC",
-        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+        "previous_commit":"3c94649865cf3770f32a645212cfc8a6b946e434",
         "source_type_CV_modified":"Fri Sep 8 17:57:00 2017 -0700",
         "source_type_CV_note":"Issue396 durack1 augment source_type with description (#399)",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"

--- a/CMIP6_source_type.json
+++ b/CMIP6_source_type.json
@@ -12,11 +12,11 @@
         "SLAB":"slab-ocean used with an AGCM in representing the atmosphere-ocean coupled system"
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "source_type_CV_modified":"Fri Sep 8 17:57:00 2017 -0700",
         "source_type_CV_note":"Issue396 durack1 augment source_type with description (#399)",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"

--- a/CMIP6_sub_experiment_id.json
+++ b/CMIP6_sub_experiment_id.json
@@ -76,11 +76,11 @@
         "s2029":"initialized near end of year 2029"
     },
     "version_metadata":{
-        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_modified":"Thu May 26 11:27:09 2022 -0700",
         "CV_collection_version":"6.2.57.1",
         "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "institution_id":"MOHC",
-        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+        "previous_commit":"3c94649865cf3770f32a645212cfc8a6b946e434",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)",
         "sub_experiment_id_CV_modified":"Mon Jun 17 11:01:51 2019 -0700",
         "sub_experiment_id_CV_note":"Revise sub_experiment_id values"

--- a/CMIP6_sub_experiment_id.json
+++ b/CMIP6_sub_experiment_id.json
@@ -76,11 +76,11 @@
         "s2029":"initialized near end of year 2029"
     },
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)",
         "sub_experiment_id_CV_modified":"Mon Jun 17 11:01:51 2019 -0700",
         "sub_experiment_id_CV_note":"Revise sub_experiment_id values"

--- a/CMIP6_table_id.json
+++ b/CMIP6_table_id.json
@@ -45,11 +45,11 @@
         "fx"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_modified":"Thu May 26 11:27:09 2022 -0700",
         "CV_collection_version":"6.2.57.1",
         "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "institution_id":"MOHC",
-        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+        "previous_commit":"3c94649865cf3770f32a645212cfc8a6b946e434",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)",
         "table_id_CV_modified":"Fri Jan 13 09:27:00 2017 -0700",
         "table_id_CV_note":"Issue199 durack1 update table_id to Data Request v1.0 (#200)"

--- a/CMIP6_table_id.json
+++ b/CMIP6_table_id.json
@@ -45,11 +45,11 @@
         "fx"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)",
         "table_id_CV_modified":"Fri Jan 13 09:27:00 2017 -0700",
         "table_id_CV_note":"Issue199 durack1 update table_id to Data Request v1.0 (#200)"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CMIP6_CVs [![stable version](https://img.shields.io/badge/Current%20version-6.2.57.0-brightgreen.svg)](https://github.com/WCRP-CMIP/CMIP6_CVs/releases/tag/6.2.57.0)
+# CMIP6_CVs [![stable version](https://img.shields.io/badge/Current%20version-6.2.57.1-brightgreen.svg)](https://github.com/WCRP-CMIP/CMIP6_CVs/releases/tag/6.2.57.1)
 
 Core Controlled Vocabularies (CVs) for use in CMIP6
 

--- a/docs/CMIP6_experiment_id.html
+++ b/docs/CMIP6_experiment_id.html
@@ -21,7 +21,7 @@ $(document).ready( function () {
 <title>CMIP6 experiment_id values</title>
 </head>
 <body>
-<p>WCRP-CMIP CMIP6_CVs version: 6.2.57.0</p>
+<p>WCRP-CMIP CMIP6_CVs version: 6.2.57.1</p>
 <table id="table_id" class="display compact" style="width:100%">
 <thead>
 <tr>

--- a/docs/CMIP6_institution_id.html
+++ b/docs/CMIP6_institution_id.html
@@ -21,7 +21,7 @@ $(document).ready( function () {
 <title>CMIP6 institution_id values</title>
 </head>
 <body>
-<p>WCRP-CMIP CMIP6_CVs version: 6.2.57.0</p>
+<p>WCRP-CMIP CMIP6_CVs version: 6.2.57.1</p>
 <table id="table_id" class="display compact" style="width:100%">
 <thead>
 <tr>

--- a/docs/CMIP6_source_id.html
+++ b/docs/CMIP6_source_id.html
@@ -21,7 +21,7 @@ $(document).ready( function () {
 <title>CMIP6 source_id values</title>
 </head>
 <body>
-<p>WCRP-CMIP CMIP6_CVs version: 6.2.57.0</p>
+<p>WCRP-CMIP CMIP6_CVs version: 6.2.57.1</p>
 <table id="table_id" class="display compact" style="width:100%">
 <thead>
 <tr>
@@ -2872,7 +2872,7 @@ $(document).ready( function () {
 <td>MOHC NERC NIMS-KMA NIWA</td>
 <td>2021</td>
 <td>CMIP ScenarioMIP</td>
-<td>Registered</td>
+<td>Published</td>
 <td>UKESM1.1-LL</td>
 <td>UKESM1.1-N96ORCA1</td>
 <td>MetUM-HadGEM3-GA7.1 (N96; 192 x 144 longitude/latitude; 85 levels; top level 85 km)</td>

--- a/docs/CMIP6_source_id_licenses.html
+++ b/docs/CMIP6_source_id_licenses.html
@@ -1737,7 +1737,7 @@ $(document).ready( function () {
 <td>UKESM1.1-N96ORCA1</td>
 <td><a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a></td>
 <td>@metoffice.gov.uk <- cmip6.ukesm1</td>
-<td>2022-05-04: initially published under CC BY-SA 4.0; 2021-11-15: relaxed to CC BY 4.0</td>
+<td>2022-05-04: initially published under CC BY-SA 4.0; 2022-05-04: relaxed to CC BY 4.0</td>
 <td><a href="https://ukesm.ac.uk/licensing-of-met-office-nerc-and-niwa-cmip6-data/">https://ukesm.ac.uk/licensing-of-met-office-nerc-and-niwa-cmip6-data/</a></td>
 </tr>
 <tr>

--- a/docs/CMIP6_source_id_licenses.html
+++ b/docs/CMIP6_source_id_licenses.html
@@ -21,7 +21,7 @@ $(document).ready( function () {
         <title>CMIP6 source_id license details</title>
 </head>
 <body>
-        <p>WCRP-CMIP CMIP6_CVs version: 6.2.57.0</p>
+        <p>WCRP-CMIP CMIP6_CVs version: 6.2.57.1</p>
         <table id="table_id" class="display compact" style="width:100%">
 
         <thead><tr>
@@ -1732,13 +1732,13 @@ $(document).ready( function () {
 <td>UKESM1-1-LL</td>
 <td>MOHC NERC NIMS-KMA NIWA</td>
 <td>2021</td>
-<td>Registered</td>
+<td>Published</td>
 <td>UKESM1.1-LL</td>
 <td>UKESM1.1-N96ORCA1</td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
+<td><a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a></td>
+<td>@metoffice.gov.uk <- cmip6.ukesm1</td>
+<td>2022-05-04: initially published under CC BY-SA 4.0; 2021-11-15: relaxed to CC BY 4.0</td>
+<td><a href="https://ukesm.ac.uk/licensing-of-met-office-nerc-and-niwa-cmip6-data/">https://ukesm.ac.uk/licensing-of-met-office-nerc-and-niwa-cmip6-data/</a></td>
 </tr>
 <tr>
 <td>UKESM1-ice-LL</td>

--- a/mip_era.json
+++ b/mip_era.json
@@ -7,13 +7,13 @@
         "CMIP6"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Tue May 24 11:20:06 2022 -0700",
-        "CV_collection_version":"6.2.57.0",
-        "author":"Paul J. Durack <durack1@llnl.gov>",
-        "institution_id":"PCMDI",
+        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_version":"6.2.57.1",
+        "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
+        "institution_id":"MOHC",
         "mip_era_CV_modified":"Thu Aug 25 17:21:00 2016 -0700",
         "mip_era_CV_note":"Fix #36 - Add CV name to json structure",
-        "previous_commit":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
+        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/mip_era.json
+++ b/mip_era.json
@@ -7,13 +7,13 @@
         "CMIP6"
     ],
     "version_metadata":{
-        "CV_collection_modified":"Thu May 26 13:10:15 2022 00100",
+        "CV_collection_modified":"Thu May 26 11:27:09 2022 -0700",
         "CV_collection_version":"6.2.57.1",
         "author":"Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>",
         "institution_id":"MOHC",
         "mip_era_CV_modified":"Thu Aug 25 17:21:00 2016 -0700",
         "mip_era_CV_note":"Fix #36 - Add CV name to json structure",
-        "previous_commit":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+        "previous_commit":"3c94649865cf3770f32a645212cfc8a6b946e434",
         "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
     }
 }

--- a/src/versionHistory.json
+++ b/src/versionHistory.json
@@ -61,10 +61,10 @@
             "timeStamp":"Thu Dec 19 15:32:17 2019 -0800"
         },
         "source_id":{
-            "MD5":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
-            "URL":"https://github.com/WCRP-CMIP/CMIP6_CVs/commit/bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+            "MD5":"3c94649865cf3770f32a645212cfc8a6b946e434",
+            "URL":"https://github.com/WCRP-CMIP/CMIP6_CVs/commit/3c94649865cf3770f32a645212cfc8a6b946e434",
             "commitMessage":"Update UKESM1-1-LL publication status and license info",
-            "timeStamp":"Thu May 26 13:10:15 2022 00100"
+            "timeStamp":"Thu May 26 11:27:09 2022 -0700"
         },
         "source_type":{
             "MD5":"fa3f07e9c215b35e0a54737acba2c2a9f6b8901f",

--- a/src/versionHistory.json
+++ b/src/versionHistory.json
@@ -61,10 +61,10 @@
             "timeStamp":"Thu Dec 19 15:32:17 2019 -0800"
         },
         "source_id":{
-            "MD5":"9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
-            "URL":"https://github.com/WCRP-CMIP/CMIP6_CVs/commit/9d190e9404ae29cac4aed8e0d2fa62b85d6a1157",
-            "commitMessage":"Update published source_id entries with rights; augment license",
-            "timeStamp":"Tue May 24 11:20:06 2022 -0700"
+            "MD5":"bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+            "URL":"https://github.com/WCRP-CMIP/CMIP6_CVs/commit/bb36f0dcc0d4b3d9c17b0214e0783e031b9bbfc9",
+            "commitMessage":"Update UKESM1-1-LL publication status and license info",
+            "timeStamp":"Thu May 26 13:10:15 2022 00100"
         },
         "source_type":{
             "MD5":"fa3f07e9c215b35e0a54737acba2c2a9f6b8901f",
@@ -85,7 +85,7 @@
             "timeStamp":"Fri Jan 13 09:27:00 2017 -0700"
         },
         "versions":{
-            "versionCVCommit":0,
+            "versionCVCommit":1,
             "versionCVContent":57,
             "versionCVStructure":2,
             "versionMIPEra":6

--- a/src/writeJson.py
+++ b/src/writeJson.py
@@ -17,6 +17,12 @@ import gc
 import datetime
 import calendar
 
+# %% additional import statements
+try:
+    from urllib2 import urlopen  # py2
+except ImportError:
+    from urllib.request import urlopen  # py3
+
 """
 Created on Mon Jul 11 14:12:21 2016
 
@@ -568,20 +574,11 @@ PJD 19 May 2022    - Update HadGEM3* license info; updated upstreams
 MSM 24 May 2022    - Removed UKESM1-0-MMh https://github.com/WCRP-CMIP/CMIP6_CVs/issues/1067
 PJD 24 May 2022    - Update with master; tweak license https://github.com/WCRP-CMIP/CMIP6_CVs/issues/1050
 PJD 24 May 2022    - Update source_id license info following https://github.com/WCRP-CMIP/CMIP6_CVs/pull/1069/files
+MSM 26 May 2022    - Added UKESM1-1-LL https://github.com/WCRP-CMIP/CMIP6_CVs/issues/1071
                      - TODO: Review all start/end_year pairs for experiments https://github.com/WCRP-CMIP/CMIP6_CVs/issues/845
                      - TODO: Generate table_id from dataRequest https://github.com/WCRP-CMIP/CMIP6_CVs/issues/166
 @author: durack1
 """
-
-# %% additional import statements
-try:
-    from urllib2 import urlopen  # py2
-except ImportError:
-    from urllib.request import urlopen  # py3
-# sys.path.insert(0, '~/sync/git/durolib/durolib')  # trustym
-#import pyexcel_xlsx as pyx
-#from string import replace
-#from unidecode import unidecode
 
 # %% Set commit message and author info
 commitMessage = '\"Update UKESM1-1-LL publication status and license info\"'
@@ -1041,32 +1038,14 @@ del(tmp)
 # Fix issues
 key = 'UKESM1-1-LL'
 source_id[key]['license_info'] = {
-    "exceptions_contact":"@metoffice.gov.uk <- cmip6.ukesm1",
-    "history":"2022-05-04: initially published under CC BY-SA 4.0; 2021-11-15: relaxed to CC BY 4.0",
-    "id":"CC BY 4.0",
-    "license":"Creative Commons Attribution 4.0 International License (CC BY 4.0; https://creativecommons.org/licenses/by/4.0/)",
-    "source_specific_info":"https://ukesm.ac.uk/licensing-of-met-office-nerc-and-niwa-cmip6-data/",
-    "url":"https://creativecommons.org/licenses/by/4.0/"
+    "exceptions_contact": "@metoffice.gov.uk <- cmip6.ukesm1",
+    "history": "2022-05-04: initially published under CC BY-SA 4.0; 2022-05-04: relaxed to CC BY 4.0",
+    "id": "CC BY 4.0",
+    "license": "Creative Commons Attribution 4.0 International License (CC BY 4.0; https://creativecommons.org/licenses/by/4.0/)",
+    "source_specific_info": "https://ukesm.ac.uk/licensing-of-met-office-nerc-and-niwa-cmip6-data/",
+    "url": "https://creativecommons.org/licenses/by/4.0/"
 }
 source_id[key]['cohort'] = ['Published']
-# f = "220524_CMIP6-CMIP_mergedMetadata.json"
-# counter = 1
-# with open(f) as fh:
-#     rightsMeta = json.load(fh)
-# # Loop through entries and add to source_id
-# for count, srcId in enumerate(rightsMeta.keys()):
-#     if "license_info" in rightsMeta[srcId].keys():
-#         print(count, srcId, "found")
-#         # add rights
-#         source_id[srcId]["license_info"] = {}
-#         source_id[srcId]["license_info"] = rightsMeta[srcId]["license_info"]
-#         # toggle cohort
-#         source_id[srcId]["cohort"] = ["Published"]
-#     else:
-#         print("----------")
-#         print(count, counter, srcId, "not found")
-#         counter = counter+1
-# del(rightsMeta)
 
 # Example
 # key = 'GISS-E2-2-H'

--- a/src/writeJson.py
+++ b/src/writeJson.py
@@ -584,11 +584,11 @@ except ImportError:
 #from unidecode import unidecode
 
 # %% Set commit message and author info
-commitMessage = '\"Update published source_id entries with rights; augment license\"'
-#author = 'Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>'
-#author_institution_id = 'MOHC'
-author = 'Paul J. Durack <durack1@llnl.gov>'
-author_institution_id = 'PCMDI'
+commitMessage = '\"Update UKESM1-1-LL publication status and license info\"'
+author = 'Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>'
+author_institution_id = 'MOHC'
+#author = 'Paul J. Durack <durack1@llnl.gov>'
+#author_institution_id = 'PCMDI'
 
 # %% List target controlled vocabularies (CVs)
 masterTargets = [
@@ -1039,24 +1039,34 @@ source_id = source_id.get('source_id')  # Fudge to extract duplicate level
 del(tmp)
 
 # Fix issues
-f = "220524_CMIP6-CMIP_mergedMetadata.json"
-counter = 1
-with open(f) as fh:
-    rightsMeta = json.load(fh)
-# Loop through entries and add to source_id
-for count, srcId in enumerate(rightsMeta.keys()):
-    if "license_info" in rightsMeta[srcId].keys():
-        print(count, srcId, "found")
-        # add rights
-        source_id[srcId]["license_info"] = {}
-        source_id[srcId]["license_info"] = rightsMeta[srcId]["license_info"]
-        # toggle cohort
-        source_id[srcId]["cohort"] = ["Published"]
-    else:
-        print("----------")
-        print(count, counter, srcId, "not found")
-        counter = counter+1
-del(rightsMeta)
+key = 'UKESM1-1-LL'
+source_id[key]['license_info'] = {
+    "exceptions_contact":"@metoffice.gov.uk <- cmip6.ukesm1",
+    "history":"2022-05-04: initially published under CC BY-SA 4.0; 2021-11-15: relaxed to CC BY 4.0",
+    "id":"CC BY 4.0",
+    "license":"Creative Commons Attribution 4.0 International License (CC BY 4.0; https://creativecommons.org/licenses/by/4.0/)",
+    "source_specific_info":"https://ukesm.ac.uk/licensing-of-met-office-nerc-and-niwa-cmip6-data/",
+    "url":"https://creativecommons.org/licenses/by/4.0/"
+}
+source_id[key]['cohort'] = ['Published']
+# f = "220524_CMIP6-CMIP_mergedMetadata.json"
+# counter = 1
+# with open(f) as fh:
+#     rightsMeta = json.load(fh)
+# # Loop through entries and add to source_id
+# for count, srcId in enumerate(rightsMeta.keys()):
+#     if "license_info" in rightsMeta[srcId].keys():
+#         print(count, srcId, "found")
+#         # add rights
+#         source_id[srcId]["license_info"] = {}
+#         source_id[srcId]["license_info"] = rightsMeta[srcId]["license_info"]
+#         # toggle cohort
+#         source_id[srcId]["cohort"] = ["Published"]
+#     else:
+#         print("----------")
+#         print(count, counter, srcId, "not found")
+#         counter = counter+1
+# del(rightsMeta)
 
 # Example
 # key = 'GISS-E2-2-H'


### PR DESCRIPTION
Addresses #1071 

Note I've left the history for UKESM1-1-LL as originally suggested as the license text in the file is still the `CC BY-SA` version.

This branch will likely conflict with #1070, but I can sort that out fairly easily
