### PR TITLE
Revised AWI-ESM-1-REcoM activity participation

### DIFF
--- a/CMIP6_source_id.json
+++ b/CMIP6_source_id.json
@@ -605,6 +605,7 @@
         "AWI-ESM-1-REcoM":{
             "activity_participation":[
                 "C4MIP",
+                "CDRMIP",
                 "CMIP",
                 "ScenarioMIP"
             ],


### PR DESCRIPTION
add cdrmip

I don't know why CMIP6_source_id.json:L8199-8200 were changed, I did not do this.