### PR TITLE
fix(composite): override subexp_variant to reference sub_experiment_id

### DIFF
--- a/member_id/subexp_variant.json
+++ b/member_id/subexp_variant.json
@@ -1,5 +1,18 @@
 {
     "@context": "000_context.jsonld",
     "id": "subexp_variant",
+    "separator": "-",
+    "parts": [
+        {
+            "type": "sub_experiment_id",
+            "is_required": false
+        },
+        {
+            "type": "variant_label",
+            "id": "ripf",
+            "is_required": true
+        }
+    ],
+    "description": "",
     "type": "member_id"
 }


### PR DESCRIPTION
## Summary

- Override the `subexp_variant` composite term spec to reference `sub_experiment_id` (the project's collection name) instead of `sub_experiment` (the universe data descriptor name).
- This makes the project DB self-contained for validation — users no longer need the universe DB installed to run `esgvoc valid` or `esgvoc drsvalid`.

## Context

The composite term `subexp_variant` in `member_id` inherited its spec from the universe, which references `"type": "sub_experiment"`. But this project's collection is named `sub_experiment_id`. With the upcoming esgvoc 5.0.0, validation resolves composite parts using project collections only, so the composite spec must reference the correct project collection name.

## Test plan

- [ ] Build project DB with `esgvoc admin build` using local universe + this branch
- [ ] Verify `esgvoc valid 'r1i1p1f1' cmip6:member_id:` works without universe installed
- [ ] Verify `esgvoc valid 's1950-r1i1p1f1' cmip6:member_id:` works without universe installed